### PR TITLE
release 1.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@userflux/browser-js-react",
-	"version": "1.5.9",
+	"version": "1.6.0",
 	"description": "UserFlux's React SDK - send your frontend analytics data to the UserFlux platform",
 	"main": "dist/index.js",
 	"module": "dist/index.esm.js",

--- a/src/index.js
+++ b/src/index.js
@@ -274,9 +274,11 @@ class UserFlux {
 		// Track initial
 		UserFlux.trackPageView()
 
-		// Track page show (e.g., back/forward navigation)
+		// Track page show from back/forward cache restoration
 		window.addEventListener("pageshow", async (event) => {
-			await UserFlux.trackPageView()
+			if (event.persisted) {
+				await UserFlux.trackPageView()
+			}
 		})
 
 		// Track history changes (works for both regular navigation and SPAs)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adjusts `page_view` auto-capture behavior on `pageshow`, which could change analytics counts (especially around back/forward navigation) if assumptions about `event.persisted` differ across browsers.
> 
> **Overview**
> Bumps the SDK version to `1.6.0`.
> 
> Updates `setupPageViewListener` so the `pageshow` handler only calls `trackPageView()` when the page is restored from the back/forward cache (`event.persisted`), reducing duplicate `page_view` events on normal page show events.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3df3e3bc7186050add1a43de24ec873a8c9c4eda. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->